### PR TITLE
Add support for config objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,30 @@ netlify-ts public/admin/config.yml src/my-types.ts
 
 In case the CLI doesn't suit your project workflow or you need to invoke the type generation inside your code, the project exposes both a `createNetlifyTypes` and `createNetlifyTypesAsync` function that returns the generated type file as a string.
 
-Sync
+### Config file
+
 ```javascript
 const fs = require("fs");
 const { createNetlifyTypes } = require("netlify-ts");
 
 function main() {
   const types = createNetlifyTypes("public/admin/config.yml");
+  fs.writeFileSync("my-types.ts", types);
+}
+
+main();
+```
+
+### Config object
+
+```javascript
+const fs = require("fs");
+const { createNetlifyTypes } = require("netlify-ts");
+
+const cmsConfig = require("./config");
+
+function main() {
+  const types = createNetlifyTypes(cmsConfig);
   fs.writeFileSync("my-types.ts", types);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export const createNetlifyTypes = (
 };
 
 export const createNetlifyTypesAsync = async (
-  input: string,
+  input: string | NetlifyCMSConfig,
   options?: NetlifyTsOptions,
 ): Promise<string> => {
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { generateTypes } from "./generate";
-import { NetlifyCMSConfig, loadConfig } from "./input";
-import type { NetlifyTsOptions } from "./types";
+import { loadConfig } from "./input";
+import type { NetlifyCMSConfig, NetlifyTsOptions } from "./types";
 
 export const createNetlifyTypes = (
   input: string | NetlifyCMSConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
 import { generateTypes } from "./generate";
-import { loadConfig } from "./input";
+import { NetlifyCMSConfig, loadConfig } from "./input";
 import type { NetlifyTsOptions } from "./types";
 
-export const createNetlifyTypes = (input: string, options: NetlifyTsOptions = {}): string => {
+export const createNetlifyTypes = (
+  input: string | NetlifyCMSConfig,
+  options: NetlifyTsOptions = {},
+): string => {
   const collections = loadConfig(input);
 
   return generateTypes(collections, options);

--- a/src/input.spec.ts
+++ b/src/input.spec.ts
@@ -1,10 +1,24 @@
-import { loadConfig } from "./input";
+import yaml from "js-yaml";
+import fs from "fs";
+import { NetlifyCMSConfig, loadConfig } from "./input";
+
+const mockConfigObject = yaml.load(
+  fs.readFileSync("kitchen-sink.yml", "utf-8"),
+) as NetlifyCMSConfig;
 
 describe("Load configuration", () => {
-  it("should return collections", () => {
+  it("should return collections from yaml config file", () => {
     const result = loadConfig("kitchen-sink.yml");
 
     expect(result.length).toBeDefined();
+    expect(result).toEqual(mockConfigObject.collections);
+  });
+
+  it("should return collections from config object", () => {
+    const result = loadConfig(mockConfigObject);
+
+    expect(result.length).toBeDefined();
+    expect(result).toEqual(mockConfigObject.collections);
   });
 
   it("should throw if invalid filetype", () => {
@@ -14,6 +28,11 @@ describe("Load configuration", () => {
 
   it("should throw if malformed config file", () => {
     const t = () => loadConfig(".github/workflows/build-test.yml");
-    expect(t).toThrow("Failed loading collections from config file");
+    expect(t).toThrow("Failed loading collections from config");
+  });
+
+  it("should throw if malformed config object", () => {
+    const t = () => loadConfig({ foo: "bar" } as NetlifyCMSConfig);
+    expect(t).toThrow("Failed loading collections from config");
   });
 });

--- a/src/input.spec.ts
+++ b/src/input.spec.ts
@@ -1,6 +1,7 @@
 import yaml from "js-yaml";
 import fs from "fs";
-import { NetlifyCMSConfig, loadConfig } from "./input";
+import { loadConfig } from "./input";
+import type { NetlifyCMSConfig } from "./types";
 
 const mockConfigObject = yaml.load(
   fs.readFileSync("kitchen-sink.yml", "utf-8"),

--- a/src/input.ts
+++ b/src/input.ts
@@ -3,21 +3,29 @@ import fs from "fs";
 import path from "path";
 import type { Collection } from "./types";
 
-interface YamlInput {
+export interface NetlifyCMSConfig {
   collections?: Collection[];
 }
 
-export const loadConfig = (filePath: string): Collection[] => {
-  if (!path.extname(filePath).match(/\.ya?ml$/)) {
-    throw new Error("Invalid filetype, must be an yaml file");
+export const loadConfig = (config: string | NetlifyCMSConfig): Collection[] => {
+  let data;
+
+  if (typeof config === "object") {
+    data = config;
   }
 
-  const file = fs.readFileSync(path.resolve(process.cwd(), filePath), "utf8");
+  if (typeof config === "string") {
+    if (!path.extname(config).match(/\.ya?ml$/)) {
+      throw new Error("Invalid filetype, must be an yaml file");
+    }
 
-  const data = yaml.load(file) as YamlInput;
+    const file = fs.readFileSync(path.resolve(process.cwd(), config), "utf8");
+
+    data = yaml.load(file) as NetlifyCMSConfig;
+  }
 
   if (typeof data !== "object" || !data.collections) {
-    throw new Error("Failed loading collections from config file");
+    throw new Error("Failed loading collections from config");
   }
 
   return data.collections;

--- a/src/input.ts
+++ b/src/input.ts
@@ -11,13 +11,7 @@ export const loadConfig = (config: string | NetlifyCMSConfig): Collection[] => {
   }
 
   if (typeof config === "string") {
-    if (!path.extname(config).match(/\.ya?ml$/)) {
-      throw new Error("Invalid filetype, must be an yaml file");
-    }
-
-    const file = fs.readFileSync(path.resolve(process.cwd(), config), "utf8");
-
-    data = yaml.load(file) as NetlifyCMSConfig;
+    data = loadConfigFile(config);
   }
 
   if (typeof data !== "object" || !data.collections) {
@@ -25,4 +19,14 @@ export const loadConfig = (config: string | NetlifyCMSConfig): Collection[] => {
   }
 
   return data.collections;
+};
+
+const loadConfigFile = (fileName: string): NetlifyCMSConfig => {
+  if (!path.extname(fileName).match(/\.ya?ml$/)) {
+    throw new Error("Invalid filetype, must be an yaml file");
+  }
+
+  const file = fs.readFileSync(path.resolve(process.cwd(), fileName), "utf8");
+
+  return yaml.load(file) as NetlifyCMSConfig;
 };

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,11 +1,7 @@
 import yaml from "js-yaml";
 import fs from "fs";
 import path from "path";
-import type { Collection } from "./types";
-
-export interface NetlifyCMSConfig {
-  collections?: Collection[];
-}
+import type { Collection, NetlifyCMSConfig } from "./types";
 
 export const loadConfig = (config: string | NetlifyCMSConfig): Collection[] => {
   let data;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,0 +1,5 @@
+import { Collection } from "./fields";
+
+export interface NetlifyCMSConfig {
+  collections?: Collection[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export type { Field, Collection } from "./fields";
 export type { Widget } from "./widgets";
 export type { NetlifyTsOptions } from "./options";
+export type { NetlifyCMSConfig } from "./config";


### PR DESCRIPTION
👋  Hey, thanks for a great package!

[We generate our Netlify CMS config object](https://github.com/29ki/29k/blob/main/cms/src/index.js#L17) and therefore can't use yaml. I don't know how common this is, as it's undocumented. But I thought it would be a good addition to your project as we really want to use this in our setup.

Let me know if you like it and I can update the `README.md` on this too.