### PR TITLE
Treat all non alphanumeric characters as delimiters

### DIFF
--- a/src/__snapshots__/generate.spec.ts.snap
+++ b/src/__snapshots__/generate.spec.ts.snap
@@ -345,7 +345,7 @@ export interface KitchenSink_TypedList_type3Object {
   file: string;
 }
 
-export interface KitchenSink_TypedList_type_4_object {
+export interface KitchenSink_TypedList_type4Object {
   type: \\"type_4_object\\";
   name: string;
 }
@@ -380,7 +380,7 @@ export interface KitchenSink {
   hidden: any;
   object: KitchenSink_Object;
   list: KitchenSink_List[];
-  typed_list: (KitchenSink_TypedList_Type1Object | KitchenSink_TypedList_Type2Object | KitchenSink_TypedList_type3Object | KitchenSink_TypedList_type_4_object)[];
+  typed_list: (KitchenSink_TypedList_Type1Object | KitchenSink_TypedList_Type2Object | KitchenSink_TypedList_type3Object | KitchenSink_TypedList_type4Object)[];
   code: KitchenSink_CodeBlock;
   code_alt: KitchenSink_CodeAltBlock;
   snippet: string;

--- a/src/widget/transform.spec.ts
+++ b/src/widget/transform.spec.ts
@@ -724,23 +724,8 @@ describe("Pull typename", () => {
 });
 
 describe("Capitalization", () => {
-  it("should capitalize words separated by spaces", () => {
-    const str = "space separated string";
-    expect(toCapitalized(str)).toBe("Space Separated String");
-  });
-
-  it("should capitalize words separated by dashes", () => {
-    const str = "dash-separated-string";
-    expect(toCapitalized(str)).toBe("Dash-Separated-String");
-  });
-
-  it("should capitalize words separated by underscores", () => {
-    const str = "underscore_separated_string";
-    expect(toCapitalized(str)).toBe("Underscore_Separated_String");
-  });
-
-  it("should handle mixed separators", () => {
-    const str = "string with-mixed_separators";
-    expect(toCapitalized(str)).toBe("String With-Mixed_Separators");
+  it("should capitalize words separated by any non-alphanumeric char", () => {
+    const str = "this is  a_string.with!non-alphanumeric#delimiters";
+    expect(toCapitalized(str)).toBe("This Is  A_String.With!Non-Alphanumeric#Delimiters");
   });
 });

--- a/src/widget/transform.spec.ts
+++ b/src/widget/transform.spec.ts
@@ -7,6 +7,7 @@ import {
   sortTypes,
   TransformState,
   toCapitalized,
+  toCamelCase,
 } from "./transform";
 
 describe("Widget transformation", () => {
@@ -723,8 +724,15 @@ describe("Pull typename", () => {
   });
 });
 
-describe("Capitalization", () => {
-  it("should capitalize words separated by any non-alphanumeric char", () => {
+describe("toCamelCase", () => {
+  it("should camelCase words separated by any non-alphanumeric characters", () => {
+    const str = "this is  a_string.with!non-alphanumeric#delimiters";
+    expect(toCamelCase(str)).toBe("thisIsAStringWithNonAlphanumericDelimiters");
+  });
+});
+
+describe("toCapitalized", () => {
+  it("should capitalize words separated by any non-alphanumeric characters", () => {
     const str = "this is  a_string.with!non-alphanumeric#delimiters";
     expect(toCapitalized(str)).toBe("This Is  A_String.With!Non-Alphanumeric#Delimiters");
   });

--- a/src/widget/transform.spec.ts
+++ b/src/widget/transform.spec.ts
@@ -8,6 +8,7 @@ import {
   TransformState,
   toCapitalized,
   toCamelCase,
+  toDelimiter,
 } from "./transform";
 
 describe("Widget transformation", () => {
@@ -735,5 +736,12 @@ describe("toCapitalized", () => {
   it("should capitalize words separated by any non-alphanumeric characters", () => {
     const str = "this is  a_string.with!non-alphanumeric#delimiters";
     expect(toCapitalized(str)).toBe("This Is  A_String.With!Non-Alphanumeric#Delimiters");
+  });
+});
+
+describe("toDelimiter", () => {
+  it("replace any non-alphanumeric character with custom delimiter", () => {
+    const str = "this is  a_string.with!non-alphanumeric#delimiters";
+    expect(toDelimiter(str, "_")).toBe("this_is_a_string_with_non_alphanumeric_delimiters");
   });
 });

--- a/src/widget/transform.spec.ts
+++ b/src/widget/transform.spec.ts
@@ -663,10 +663,10 @@ describe("Widget transformation", () => {
         { prefix: "parent", label: true },
       ),
     ).toEqual([
-      ["list: (parent_my_list_typeOne | parent_my_list_type_two)[];"],
+      ["list: (parent_myList_typeOne | parent_myList_typeTwo)[];"],
       [
-        `interface parent_my_list_typeOne { __typename: "type_one"; key: string; }`,
-        `interface parent_my_list_type_two { __typename: "two"; id: number; }`,
+        `interface parent_myList_typeOne { __typename: "type_one"; key: string; }`,
+        `interface parent_myList_typeTwo { __typename: "two"; id: number; }`,
       ],
     ]);
   });

--- a/src/widget/transform.ts
+++ b/src/widget/transform.ts
@@ -11,19 +11,18 @@ export const getWidgetName = (
   delimiter: string,
 ): string =>
   getName(
-    useLabel
-      ? (widget.singularLabel || widget.label || widget.name).replace(/\s./gi, toCamelCase)
-      : widget.name,
+    useLabel ? toCamelCase(widget.singularLabel || widget.label || widget.name) : widget.name,
     capitalize,
     delimiter,
   );
 
-export const toCamelCase = (str: string): string => str.slice(1).toUpperCase();
+export const toCamelCase = (str: string): string =>
+  str.replace(/([^a-z\d]+)([a-z\d])/gi, (match, delimiter, char) => char.toUpperCase());
 
 export const toCapitalized = (str: string) =>
   str.replace(
     /(^|[^a-z\d])([a-z\d])/gi,
-    (match, separator, char) => `${separator}${char.toUpperCase()}`,
+    (match, delimiter, char) => `${delimiter}${char.toUpperCase()}`,
   );
 
 export const toDelimiter = (str: string, delimiter: string) => str.replace(/[\s-_]/g, delimiter);

--- a/src/widget/transform.ts
+++ b/src/widget/transform.ts
@@ -25,7 +25,8 @@ export const toCapitalized = (str: string) =>
     (match, delimiter, char) => `${delimiter}${char.toUpperCase()}`,
   );
 
-export const toDelimiter = (str: string, delimiter: string) => str.replace(/[\s-_]/g, delimiter);
+export const toDelimiter = (str: string, delimiter: string) =>
+  str.replace(/[^a-z\d]+/gi, delimiter);
 
 export const wrapEnum = (item: number | string): string =>
   typeof item === "number" ? `${item}` : `"${item}"`;

--- a/src/widget/transform.ts
+++ b/src/widget/transform.ts
@@ -21,7 +21,10 @@ export const getWidgetName = (
 export const toCamelCase = (str: string): string => str.slice(1).toUpperCase();
 
 export const toCapitalized = (str: string) =>
-  str.replace(/(^|[\s-_])(\w)/g, (match, separator, char) => `${separator}${char.toUpperCase()}`);
+  str.replace(
+    /(^|[^a-z\d])([a-z\d])/gi,
+    (match, separator, char) => `${separator}${char.toUpperCase()}`,
+  );
 
 export const toDelimiter = (str: string, delimiter: string) => str.replace(/[\s-_]/g, delimiter);
 


### PR DESCRIPTION
Hi again from your favourite contributor 😄 

We noticed that it still generates type names containing non supported characters. E.g. `label: 'Foo.Bar'` would create an `interface Foo.Bar`. So in this PR I've made sure that `toCamelCase`, `toCapitalized` and `toDelimiter` all operate on all non-alphanumeric chars instead of `_-\s` as before.

This is however a breaking change as the `toCamelCase` now removes any kind of delimiter. E.g:
<img width="620" alt="Screenshot 2022-10-13 at 12 11 47" src="https://user-images.githubusercontent.com/474066/195572601-4d9d829c-a247-4b7a-8fd2-b8dec8023d0a.png">

I could make `toCamelCase` delimiter aware. E.g. `toCamelCase("my list type_two", "_")` ➡️  `myListType_two` to not cause a breaking change. Imho I wouldn't prefer that, but I leave this design decision to you.