### PR TITLE
fix: fix missing body field (#13)

### DIFF
--- a/src/widget/transform.ts
+++ b/src/widget/transform.ts
@@ -108,11 +108,6 @@ export const transformType =
     const name = getName(prefix ? `${prefix}_${widgetName}` : widgetName, capitalize, delimiter);
 
     if (!Array.isArray(widget.type)) {
-      // if widget name is `body`
-      if (widget.name === "body") {
-        return types;
-      }
-
       // if widget is a primitive
       if (typeof widget.type === "string") {
         const optional = widget.type.includes("?") ? "?" : "";


### PR DESCRIPTION
I thought `transformType()` used with `reduce()` is generally hard to understand so I might miss something(?), but as the body widget is usually string it should be covered by the next block statement `if (typeof widget.type === "string") { ...`. This seems to fix the issue and the body is including in the generated types. 